### PR TITLE
Support large body request + thread safer clients count per worker + separation between regular http requests to WS

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,137 +1,218 @@
 const cluster = require("cluster");
+const { PassThrough } = require("stream");
+
+const isWebsocketRequest = (data) => {
+    const marker = data.indexOf("\r\n\r\n");
+    const headers = data.slice(0, marker).toString();
+    if (/^Upgrade: websocket$/im.exec(headers)) {
+        return true;
+    }
+    return false;
+};
 
 const setupMaster = (httpServer, opts) => {
-  if (!cluster.isMaster) {
-    throw new Error("not master");
-  }
-
-  const options = Object.assign(
-    {
-      loadBalancingMethod: "least-connection", // either "random", "round-robin" or "least-connection"
-    },
-    opts
-  );
-
-  const sessionIdToWorker = new Map();
-  const sidRegex = /sid=([\w\-]{20})/;
-  let currentIndex = 0; // for round-robin load balancing
-
-  const computeWorkerId = (data) => {
-    const match = sidRegex.exec(data);
-    if (match) {
-      const sid = match[1];
-      const workerId = sessionIdToWorker.get(sid);
-      if (workerId && cluster.workers[workerId]) {
-        return workerId;
-      }
+    if (!cluster.isMaster) {
+        throw new Error("not master");
     }
-    switch (options.loadBalancingMethod) {
-      case "random": {
-        const workerIds = Object.keys(cluster.workers);
-        return workerIds[Math.floor(Math.random() * workerIds.length)];
-      }
-      case "round-robin": {
-        const workerIds = Object.keys(cluster.workers);
-        currentIndex++;
-        if (currentIndex >= workerIds.length) {
-          currentIndex = 0;
-        }
-        return workerIds[currentIndex];
-      }
-      case "least-connection":
-        let leastActiveWorker;
-        for (const id in cluster.workers) {
-          const worker = cluster.workers[id];
-          if (leastActiveWorker === undefined) {
-            leastActiveWorker = worker;
-          } else {
-            const c1 = worker.clientsCount || 0;
-            const c2 = leastActiveWorker.clientsCount || 0;
-            if (c1 < c2) {
-              leastActiveWorker = worker;
+
+    const options = Object.assign(
+        {
+            loadBalancingMethod: "least-connection", // either "random", "round-robin" or "least-connection"
+        },
+        opts
+    );
+
+    const sessionIdToWorker = new Map();
+    const sidRegex = /sid=([\w-]{20})/;
+    let currentIndex = 0; // for round-robin load balancing
+
+    const computeWorkerId = (data) => {
+        const match = sidRegex.exec(data);
+        if (match) {
+            const sid = match[1];
+            const workerId = sessionIdToWorker.get(sid);
+            if (workerId && cluster.workers[workerId]) {
+                return workerId;
             }
-          }
         }
-        return leastActiveWorker.id;
-    }
-  };
+        switch (options.loadBalancingMethod) {
+            case "random": {
+                const workerIds = Object.keys(cluster.workers);
+                return workerIds[Math.floor(Math.random() * workerIds.length)];
+            }
+            case "round-robin": {
+                const workerIds = Object.keys(cluster.workers);
+                currentIndex++;
+                if (currentIndex >= workerIds.length) {
+                    currentIndex = 0;
+                }
+                return workerIds[currentIndex];
+            }
+            case "least-connection": {
+                let leastActiveWorker;
+                for (const id in cluster.workers) {
+                    const worker = cluster.workers[id];
+                    if (leastActiveWorker === undefined) {
+                        leastActiveWorker = worker;
+                    } else {
+                        const c1 = worker.clientsCount || 0;
+                        const c2 = leastActiveWorker.clientsCount || 0;
+                        if (c1 < c2) {
+                            leastActiveWorker = worker;
+                        }
+                    }
+                }
+                return leastActiveWorker.id;
+            }
+        }
+    };
 
-  httpServer.on("connection", (socket) => {
-    socket.once("data", (buffer) => {
-      socket.pause();
-      const data = buffer.toString();
-      const workerId = computeWorkerId(data);
-      cluster.workers[workerId].send(
-        { type: "sticky:connection", data },
-        socket,
-        (err) => {
-          if (err) {
-            socket.destroy();
-          }
-        }
-      );
+    httpServer.on("connection", (socket) => {
+        let workerId;
+        const connectionId = Math.floor((Math.random() * 10000000));
+        socket.on("data", (buffer) => {
+            let type;
+            if (!workerId) {
+                const data = buffer.toString();
+                workerId = computeWorkerId(data);
+                if (isWebsocketRequest(data)) {
+                    type = "sticky:connection";
+                    socket.pause();
+                } else {
+                    type = "first-chunk";
+                }
+            } else {
+                type = "next-chunk";
+            }
+            cluster.workers[workerId].send(
+                {
+                    type,
+                    data: buffer,
+                    connectionId,
+                },
+                socket,
+                (err) => {
+                    if (err) {
+                        socket.destroy();
+                    }
+                }
+            );
+        });
     });
-  });
 
-  cluster.on("message", (worker, { type, data }) => {
-    switch (type) {
-      case "sticky:connection":
-        sessionIdToWorker.set(data, worker.id);
-        if (options.loadBalancingMethod === "least-connection") {
-          worker.clientsCount = (worker.clientsCount || 0) + 1;
+    // we need this dummy handler to make socket.on("data") handler works more then one time
+    httpServer.on("request", (req, _res) => {
+        req.on("data", (_data) => {});
+    });
+
+    cluster.on("fork", (worker) => {
+        worker.clientsCount = 0;
+    });
+
+    cluster.on("message", (worker, { type, data }) => {
+        switch (type) {
+            case "sticky:connection":
+                sessionIdToWorker.set(data, worker.id);
+                if (options.loadBalancingMethod === "least-connection") {
+                    worker.clientsCount++;
+                }
+                break;
+            case "sticky:disconnection":
+                sessionIdToWorker.delete(data);
+                if (options.loadBalancingMethod === "least-connection") {
+                    worker.clientsCount--;
+                }
+                break;
+            case "regularHttp:connection":
+                if (options.loadBalancingMethod === "least-connection") {
+                    worker.clientsCount++;
+                }
+                break;
+            case "regularHttp:disconnection":
+                if (options.loadBalancingMethod === "least-connection") {
+                    worker.clientsCount--;
+                }
+                break;
         }
-        break;
-      case "sticky:disconnection":
-        sessionIdToWorker.delete(data);
-        if (options.loadBalancingMethod === "least-connection") {
-          worker.clientsCount--;
-        }
-        break;
-    }
-  });
+    });
 };
 
 const setupWorker = (io) => {
-  if (!cluster.isWorker) {
-    throw new Error("not worker");
-  }
-
-  process.on("message", ({ type, data }, socket) => {
-    switch (type) {
-      case "sticky:connection":
-        if (!socket) {
-          // might happen if the socket is closed during the transfer to the worker
-          // see https://nodejs.org/api/child_process.html#child_process_example_sending_a_socket_object
-          return;
-        }
-        io.httpServer.emit("connection", socket); // inject connection
-        // republish first chunk
-        if (socket._handle.onread.length === 1) {
-          socket._handle.onread(Buffer.from(data));
-        } else {
-          // for Node.js < 12
-          socket._handle.onread(1, Buffer.from(data));
-        }
-        socket.resume();
-        break;
+    if (!cluster.isWorker) {
+        throw new Error("not worker");
     }
-  });
-
-  const ignoreError = () => {}; // the next request will fail anyway
-
-  io.engine.on("connection", (socket) => {
-    process.send({ type: "sticky:connection", data: socket.id }, ignoreError);
-
-    socket.once("close", () => {
-      process.send(
-        { type: "sticky:disconnection", data: socket.id },
-        ignoreError
-      );
+    const connections = {};
+    const ignoreError = () => {}; // the next request will fail anyway
+    process.on("message", ({ type, data, connectionId }, socket) => {
+        if (!socket) {
+            // might happen if the socket is closed during the transfer to the worker
+            // see https://nodejs.org/api/child_process.html#child_process_example_sending_a_socket_object
+            return;
+        }
+        switch (type) {
+            case "sticky:connection": {
+                io.httpServer.emit("connection", socket); // inject connection
+                // republish first chunk
+                if (socket._handle.onread.length === 1) {
+                    socket._handle.onread(Buffer.from(data));
+                } else {
+                    // for Node.js < 12
+                    socket._handle.onread(1, Buffer.from(data));
+                }
+                socket.resume();
+                break;
+            }
+            case "first-chunk": {
+                const request = data.toString();
+                const m = /content-length: (\d+).*\r\n\r\n/im.exec(request);
+                const tunnel = new PassThrough();
+                tunnel.contentLength = m ? +m[1] : 0;
+                tunnel.contentLengthReceived = data.length;
+                connections[connectionId] = tunnel;
+                io.httpServer.emit("connection", tunnel); // inject connection
+                tunnel.write(data);
+                process.send({ type: "regularHttp:connection", data: null }, ignoreError);
+                tunnel.on("data", (d) => {
+                    if (tunnel.contentLength > tunnel.contentLengthReceived) {
+                        return;
+                    }
+                    // handle exception if client closed connection on his side
+                    try {
+                        socket?.write(d);
+                    } catch (e) {
+                        log.debug("Error on socket write", e);
+                    }
+                });
+                tunnel.on("end", () => {
+                    // handle exception if client closed connection on his side
+                    try {
+                        socket?.end();
+                    } catch (e) {
+                        log.debug("Error on socket close", e);
+                    }
+                    process.send({ type: "regularHttp:disconnection", data: null }, ignoreError);
+                    delete connections[connectionId];
+                });
+                break;
+            }
+            case "next-chunk": {
+                const tunnel = connections[connectionId];
+                tunnel.write(data);
+                tunnel.contentLengthReceived += data.length;
+                break;
+            }
+        }
     });
-  });
+
+    io.engine.on("connection", (socket) => {
+        process.send({ type: "sticky:connection", data: socket.id }, ignoreError);
+        socket.once("close", () => {
+            process.send({ type: "sticky:disconnection", data: socket.id }, ignoreError);
+        });
+    });
 };
 
 module.exports = {
-  setupMaster,
-  setupWorker,
+    setupMaster,
+    setupWorker,
 };

--- a/index.js
+++ b/index.js
@@ -2,217 +2,231 @@ const cluster = require("cluster");
 const { PassThrough } = require("stream");
 
 const isWebsocketRequest = (data) => {
-    const marker = data.indexOf("\r\n\r\n");
-    const headers = data.slice(0, marker).toString();
-    if (/^Upgrade: websocket$/im.exec(headers)) {
-        return true;
-    }
-    return false;
+  const marker = data.indexOf("\r\n\r\n");
+  const headers = data.slice(0, marker).toString();
+  if (
+    /\?EIO=4&transport=(polling|websocket)/.exec(headers) ||
+    /^Upgrade: websocket$/m.exec(headers)
+  ) {
+    return true;
+  }
+  return false;
 };
 
 const setupMaster = (httpServer, opts) => {
-    if (!cluster.isMaster) {
-        throw new Error("not master");
+  if (!cluster.isMaster) {
+    throw new Error("not master");
+  }
+
+  const options = Object.assign(
+    {
+      loadBalancingMethod: "least-connection", // either "random", "round-robin" or "least-connection"
+    },
+    opts
+  );
+
+  const sessionIdToWorker = new Map();
+  const sidRegex = /sid=([\w-]{20})/;
+  let currentIndex = 0; // for round-robin load balancing
+
+  const computeWorkerId = (data) => {
+    const match = sidRegex.exec(data);
+    if (match) {
+      const sid = match[1];
+      const workerId = sessionIdToWorker.get(sid);
+      if (workerId && cluster.workers[workerId]) {
+        return workerId;
+      }
     }
+    switch (options.loadBalancingMethod) {
+      case "random": {
+        const workerIds = Object.keys(cluster.workers);
+        return workerIds[Math.floor(Math.random() * workerIds.length)];
+      }
+      case "round-robin": {
+        const workerIds = Object.keys(cluster.workers);
+        currentIndex++;
+        if (currentIndex >= workerIds.length) {
+          currentIndex = 0;
+        }
+        return workerIds[currentIndex];
+      }
+      case "least-connection": {
+        let leastActiveWorker;
+        for (const id in cluster.workers) {
+          const worker = cluster.workers[id];
+          if (leastActiveWorker === undefined) {
+            leastActiveWorker = worker;
+          } else {
+            const c1 = worker.clientsCount || 0;
+            const c2 = leastActiveWorker.clientsCount || 0;
+            if (c1 < c2) {
+              leastActiveWorker = worker;
+            }
+          }
+        }
+        return leastActiveWorker.id;
+      }
+    }
+  };
 
-    const options = Object.assign(
+  httpServer.on("connection", (socket) => {
+    let workerId;
+    const connectionId = Math.floor(Math.random() * 10000000);
+    socket.on("data", (buffer) => {
+      let type;
+      if (!workerId) {
+        const data = buffer.toString();
+        workerId = computeWorkerId(data);
+        if (isWebsocketRequest(data)) {
+          type = "sticky:connection";
+          socket.pause();
+        } else {
+          type = "first-chunk";
+        }
+      } else {
+        type = "next-chunk";
+      }
+      cluster.workers[workerId].send(
         {
-            loadBalancingMethod: "least-connection", // either "random", "round-robin" or "least-connection"
+          type,
+          data: buffer.toString(),
+          connectionId,
         },
-        opts
-    );
-
-    const sessionIdToWorker = new Map();
-    const sidRegex = /sid=([\w-]{20})/;
-    let currentIndex = 0; // for round-robin load balancing
-
-    const computeWorkerId = (data) => {
-        const match = sidRegex.exec(data);
-        if (match) {
-            const sid = match[1];
-            const workerId = sessionIdToWorker.get(sid);
-            if (workerId && cluster.workers[workerId]) {
-                return workerId;
-            }
+        socket,
+        { keepOpen: type !== "sticky:connection" },
+        (err) => {
+          if (err) {
+            socket.destroy();
+          }
         }
-        switch (options.loadBalancingMethod) {
-            case "random": {
-                const workerIds = Object.keys(cluster.workers);
-                return workerIds[Math.floor(Math.random() * workerIds.length)];
-            }
-            case "round-robin": {
-                const workerIds = Object.keys(cluster.workers);
-                currentIndex++;
-                if (currentIndex >= workerIds.length) {
-                    currentIndex = 0;
-                }
-                return workerIds[currentIndex];
-            }
-            case "least-connection": {
-                let leastActiveWorker;
-                for (const id in cluster.workers) {
-                    const worker = cluster.workers[id];
-                    if (leastActiveWorker === undefined) {
-                        leastActiveWorker = worker;
-                    } else {
-                        const c1 = worker.clientsCount || 0;
-                        const c2 = leastActiveWorker.clientsCount || 0;
-                        if (c1 < c2) {
-                            leastActiveWorker = worker;
-                        }
-                    }
-                }
-                return leastActiveWorker.id;
-            }
+      );
+    });
+  });
+
+  // we need this dummy handler to make socket.on("data") handler works more then one time
+  httpServer.on("request", (req, _res) => {
+    req.on("data", (_data) => {});
+  });
+
+  cluster.on("fork", (worker) => {
+    worker.clientsCount = 0;
+  });
+
+  cluster.on("message", (worker, { type, data }) => {
+    switch (type) {
+      case "sticky:connection":
+        sessionIdToWorker.set(data, worker.id);
+        if (options.loadBalancingMethod === "least-connection") {
+          worker.clientsCount++;
         }
-    };
-
-    httpServer.on("connection", (socket) => {
-        let workerId;
-        const connectionId = Math.floor((Math.random() * 10000000));
-        socket.on("data", (buffer) => {
-            let type;
-            if (!workerId) {
-                const data = buffer.toString();
-                workerId = computeWorkerId(data);
-                if (isWebsocketRequest(data)) {
-                    type = "sticky:connection";
-                    socket.pause();
-                } else {
-                    type = "first-chunk";
-                }
-            } else {
-                type = "next-chunk";
-            }
-            cluster.workers[workerId].send(
-                {
-                    type,
-                    data: buffer,
-                    connectionId,
-                },
-                socket,
-                (err) => {
-                    if (err) {
-                        socket.destroy();
-                    }
-                }
-            );
-        });
-    });
-
-    // we need this dummy handler to make socket.on("data") handler works more then one time
-    httpServer.on("request", (req, _res) => {
-        req.on("data", (_data) => {});
-    });
-
-    cluster.on("fork", (worker) => {
-        worker.clientsCount = 0;
-    });
-
-    cluster.on("message", (worker, { type, data }) => {
-        switch (type) {
-            case "sticky:connection":
-                sessionIdToWorker.set(data, worker.id);
-                if (options.loadBalancingMethod === "least-connection") {
-                    worker.clientsCount++;
-                }
-                break;
-            case "sticky:disconnection":
-                sessionIdToWorker.delete(data);
-                if (options.loadBalancingMethod === "least-connection") {
-                    worker.clientsCount--;
-                }
-                break;
-            case "regularHttp:connection":
-                if (options.loadBalancingMethod === "least-connection") {
-                    worker.clientsCount++;
-                }
-                break;
-            case "regularHttp:disconnection":
-                if (options.loadBalancingMethod === "least-connection") {
-                    worker.clientsCount--;
-                }
-                break;
+        break;
+      case "sticky:disconnection":
+        sessionIdToWorker.delete(data);
+        if (options.loadBalancingMethod === "least-connection") {
+          worker.clientsCount--;
         }
-    });
+        break;
+      case "regularHttp:connection":
+        if (options.loadBalancingMethod === "least-connection") {
+          worker.clientsCount++;
+        }
+        break;
+      case "regularHttp:disconnection":
+        if (options.loadBalancingMethod === "least-connection") {
+          worker.clientsCount--;
+        }
+        break;
+    }
+  });
 };
 
 const setupWorker = (io) => {
-    if (!cluster.isWorker) {
-        throw new Error("not worker");
+  if (!cluster.isWorker) {
+    throw new Error("not worker");
+  }
+  const connections = {};
+  const ignoreError = () => {}; // the next request will fail anyway
+  process.on("message", ({ type, data, connectionId }, socket) => {
+    if (!socket) {
+      // might happen if the socket is closed during the transfer to the worker
+      // see https://nodejs.org/api/child_process.html#child_process_example_sending_a_socket_object
+      return;
     }
-    const connections = {};
-    const ignoreError = () => {}; // the next request will fail anyway
-    process.on("message", ({ type, data, connectionId }, socket) => {
-        if (!socket) {
-            // might happen if the socket is closed during the transfer to the worker
-            // see https://nodejs.org/api/child_process.html#child_process_example_sending_a_socket_object
+    switch (type) {
+      case "sticky:connection": {
+        io.httpServer.emit("connection", socket); // inject connection
+        // republish first chunk
+        if (socket._handle.onread.length === 1) {
+          socket._handle.onread(Buffer.from(data));
+        } else {
+          // for Node.js < 12
+          socket._handle.onread(1, Buffer.from(data));
+        }
+        socket.resume();
+        break;
+      }
+      case "first-chunk": {
+        const request = data.toString();
+        const m = /content-length: (\d+)/im.exec(request);
+        const tunnel = new PassThrough();
+        tunnel.contentLength = m ? +m[1] : 0;
+        tunnel.contentLengthReceived = data.length;
+        connections[connectionId] = tunnel;
+        io.httpServer.emit("connection", tunnel); // inject connection
+        console.log(request, typeof data);
+        tunnel.write(data);
+        process.send(
+          { type: "regularHttp:connection", data: null },
+          ignoreError
+        );
+        tunnel.on("data", (d) => {
+          if (tunnel.contentLength > tunnel.contentLengthReceived) {
             return;
-        }
-        switch (type) {
-            case "sticky:connection": {
-                io.httpServer.emit("connection", socket); // inject connection
-                // republish first chunk
-                if (socket._handle.onread.length === 1) {
-                    socket._handle.onread(Buffer.from(data));
-                } else {
-                    // for Node.js < 12
-                    socket._handle.onread(1, Buffer.from(data));
-                }
-                socket.resume();
-                break;
-            }
-            case "first-chunk": {
-                const request = data.toString();
-                const m = /content-length: (\d+).*\r\n\r\n/im.exec(request);
-                const tunnel = new PassThrough();
-                tunnel.contentLength = m ? +m[1] : 0;
-                tunnel.contentLengthReceived = data.length;
-                connections[connectionId] = tunnel;
-                io.httpServer.emit("connection", tunnel); // inject connection
-                tunnel.write(data);
-                process.send({ type: "regularHttp:connection", data: null }, ignoreError);
-                tunnel.on("data", (d) => {
-                    if (tunnel.contentLength > tunnel.contentLengthReceived) {
-                        return;
-                    }
-                    // handle exception if client closed connection on his side
-                    try {
-                        socket?.write(d);
-                    } catch (e) {
-                        log.debug("Error on socket write", e);
-                    }
-                });
-                tunnel.on("end", () => {
-                    // handle exception if client closed connection on his side
-                    try {
-                        socket?.end();
-                    } catch (e) {
-                        log.debug("Error on socket close", e);
-                    }
-                    process.send({ type: "regularHttp:disconnection", data: null }, ignoreError);
-                    delete connections[connectionId];
-                });
-                break;
-            }
-            case "next-chunk": {
-                const tunnel = connections[connectionId];
-                tunnel.write(data);
-                tunnel.contentLengthReceived += data.length;
-                break;
-            }
-        }
-    });
-
-    io.engine.on("connection", (socket) => {
-        process.send({ type: "sticky:connection", data: socket.id }, ignoreError);
-        socket.once("close", () => {
-            process.send({ type: "sticky:disconnection", data: socket.id }, ignoreError);
+          }
+          // handle exception if client closed connection on his side
+          try {
+            socket?.write(d);
+          } catch (e) {
+            log.debug("Error on socket write", e);
+          }
         });
+        tunnel.on("end", () => {
+          // handle exception if client closed connection on his side
+          try {
+            socket?.end();
+          } catch (e) {
+            log.debug("Error on socket close", e);
+          }
+          process.send(
+            { type: "regularHttp:disconnection", data: null },
+            ignoreError
+          );
+          delete connections[connectionId];
+        });
+        break;
+      }
+      case "next-chunk": {
+        const tunnel = connections[connectionId];
+        tunnel.write(data);
+        tunnel.contentLengthReceived += data.length;
+        break;
+      }
+    }
+  });
+
+  io.engine.on("connection", (socket) => {
+    process.send({ type: "sticky:connection", data: socket.id }, ignoreError);
+    socket.once("close", () => {
+      process.send(
+        { type: "sticky:disconnection", data: socket.id },
+        ignoreError
+      );
     });
+  });
 };
 
 module.exports = {
-    setupMaster,
-    setupWorker,
+  setupMaster,
+  setupWorker,
 };

--- a/index.js
+++ b/index.js
@@ -186,7 +186,9 @@ const setupWorker = (io) => {
           }
           // handle exception if client closed connection on his side
           try {
-            socket?.write(d);
+            if (socket) {
+              socket.write(d);
+            }
           } catch (e) {
             log.debug("Error on socket write", e);
           }
@@ -194,7 +196,9 @@ const setupWorker = (io) => {
         tunnel.on("end", () => {
           // handle exception if client closed connection on his side
           try {
-            socket?.end();
+            if (socket) {
+              socket.end();
+            }
           } catch (e) {
             log.debug("Error on socket close", e);
           }

--- a/test/fixtures/connection.js
+++ b/test/fixtures/connection.js
@@ -78,7 +78,7 @@ httpServer.listen(async () => {
     for (const id in cluster.workers) {
       cluster.workers[id].kill();
     }
-    console.log("workes killed");
+    console.log("workers killed");
   } catch (e) {
     console.log(e);
     exitCode = 1;

--- a/test/fixtures/connection.js
+++ b/test/fixtures/connection.js
@@ -6,8 +6,20 @@ const { setupMaster, setupWorker } = require("../..");
 
 if (cluster.isWorker) {
   const httpServer = http.createServer();
-  const io = new Server(httpServer);
+  const io = new Server(httpServer, {
+    maxHttpBufferSize: 2 * 1e6,
+  });
   setupWorker(io);
+
+  io.on("connection", (socket) => {
+    socket.on("foo", (val) => {
+      socket.emit("bar", val);
+    });
+    socket.on("large", (val) => {
+      socket.emit("large-bar", Buffer.allocUnsafe(1e6));
+    });
+  });
+
   return;
 }
 
@@ -20,30 +32,63 @@ for (let i = 0; i < WORKER_COUNT; i++) {
 const httpServer = http.createServer();
 
 setupMaster(httpServer, {
-  loadBalancingMethod: process.env.LB_METHOD,
+  loadBalancingMethod: process.env.LB_METHOD || "least-connection",
 });
 
 const waitFor = (emitter, event) => {
-  return new Promise((resolve) => {
-    emitter.once(event, resolve);
+  return new Promise((resolve, reject) => {
+    const timeoutId = setTimeout(() => {
+      reject(new Error("timeout reached"));
+    }, 3000);
+    emitter.once(event, () => {
+      clearTimeout(timeoutId);
+      resolve();
+    });
   });
 };
 
 httpServer.listen(async () => {
-  const port = httpServer.address().port;
-  const socket = ioc(`http://localhost:${port}`);
-  await waitFor(socket, "connect");
+  let exitCode = 0;
+  let socket;
+  try {
+    const port = httpServer.address().port;
+    console.log(`Listening on port ${port}`);
 
-  socket.disconnect().connect();
-  await waitFor(socket, "connect");
+    socket = ioc(`http://localhost:${port}`, {
+      transports: process.env.TRANSPORT
+        ? [process.env.TRANSPORT]
+        : ["polling", "websocket"],
+    });
 
-  socket.disconnect().connect();
-  await waitFor(socket, "connect");
+    await waitFor(socket, "connect");
 
-  // cleanup
-  for (const id in cluster.workers) {
-    cluster.workers[id].kill();
+    socket.disconnect().connect();
+    await waitFor(socket, "connect");
+    console.log("connected");
+    socket.disconnect().connect();
+    await waitFor(socket, "connect");
+    console.log("reconnected");
+    socket.emit("foo", "hello");
+    await waitFor(socket, "bar");
+    console.log("got hello");
+    socket.emit("foo", Buffer.allocUnsafe(1e6));
+    await waitFor(socket, "bar");
+    console.log("sent large packet");
+    socket.emit("large", "hello");
+    await waitFor(socket, "large-bar");
+    console.log("got large packet");
+    // cleanup
+    for (const id in cluster.workers) {
+      cluster.workers[id].kill();
+    }
+    console.log("workes killed");
+  } catch (e) {
+    console.log(e);
+    exitCode = 1;
+  } finally {
+    if (socket && socket.connected) socket.disconnect();
+    httpServer.close(() => {
+      process.exit(exitCode);
+    });
   }
-  httpServer.close();
-  socket.disconnect();
 });

--- a/test/fixtures/connection.js
+++ b/test/fixtures/connection.js
@@ -53,9 +53,9 @@ httpServer.listen(async () => {
     const port = httpServer.address().port;
     console.log(`Listening on port ${port}`);
     const socket = ioc(`http://localhost:${port}`, {
-    transports: process.env.TRANSPORT
-       ? [process.env.TRANSPORT]
-       : ["polling", "websocket"],
+      transports: process.env.TRANSPORT
+        ? [process.env.TRANSPORT]
+        : ["polling", "websocket"],
     });
 
     await waitFor(socket, "connect");
@@ -87,6 +87,5 @@ httpServer.listen(async () => {
     httpServer.close(() => {
       process.exit(exitCode);
     });
-
   }
 });

--- a/test/index.js
+++ b/test/index.js
@@ -58,7 +58,6 @@ describe("@socket.io/sticky", () => {
     exec(fixture("connection.js"), { env: { TRANSPORT: "websocket" } }, done);
   });
 
-
   it.skip("should work with HTTP long-polling only", (done) => {
     exec(fixture("connection.js"), { env: { TRANSPORT: "polling" } }, done);
   });

--- a/test/index.js
+++ b/test/index.js
@@ -1,26 +1,56 @@
 const { join } = require("path");
 const { exec } = require("child_process");
+const assert = require("assert");
 
 const fixture = (filename) => {
   return (
     '"' + process.execPath + '" "' + join(__dirname, "fixtures", filename) + '"'
   );
 };
-
+const handler = (done) => {
+  return (error, stdOut, stdErr) => {
+    let result = null;
+    if (error) {
+      result = `${stdOut}\n${stdErr}`;
+    }
+    assert.strictEqual(result, null);
+    done();
+  };
+};
 describe("@socket.io/sticky", () => {
   it("should work with least-connection load-balancing", (done) => {
-    exec(
-      fixture("connection.js"),
-      { env: { LB_METHOD: "least-connection" } },
-      done
-    );
+    exec(fixture("connection.js"), handler(done));
   });
 
   it("should work with round-robin load-balancing", (done) => {
-    exec(fixture("connection.js"), { env: { LB_METHOD: "round-robin" } }, done);
+    exec(
+      fixture("connection.js"),
+      { env: { LB_METHOD: "round-robin" } },
+      handler(done)
+    );
   });
 
   it("should work with random load-balancing", (done) => {
-    exec(fixture("connection.js"), { env: { LB_METHOD: "random" } }, done);
+    exec(
+      fixture("connection.js"),
+      { env: { LB_METHOD: "random" } },
+      handler(done)
+    );
+  });
+
+  it("should work with WebSocket only", (done) => {
+    exec(
+      fixture("connection.js"),
+      { env: { TRANSPORT: "websocket" } },
+      handler(done)
+    );
+  });
+
+  it("should work with HTTP long-polling only", (done) => {
+    exec(
+      fixture("connection.js"),
+      { env: { TRANSPORT: "polling" } },
+      handler(done)
+    );
   });
 });

--- a/test/index.js
+++ b/test/index.js
@@ -9,11 +9,10 @@ const fixture = (filename) => {
 };
 const handler = (done) => {
   return (error, stdOut, stdErr) => {
-    let result = null;
     if (error) {
-      result = `${stdOut}\n${stdErr}`;
+      console.log(`${stdOut}\n${stdErr}`);
     }
-    assert.strictEqual(result, null);
+    assert.strictEqual(error, null);
     done();
   };
 };


### PR DESCRIPTION
Should solve: https://github.com/socketio/socket.io-sticky/issues/6

This PR includes:

- Handling of large body requests (using "data" events)
- Separation between WS to regular http requests to keep main logic for WS the same
- Thread safer client count 